### PR TITLE
Added... print "CP.steerRatio: %s" % CP.steerRatio

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -576,6 +576,7 @@ def controlsd_thread(gctx=None, rate=100, default_bias=0.):
         print "CP.steerKf: %s" % CP.steerKf
         print "CP.steerKiBP: %s" % CP.steerKiBP
         print "CP.steerKpBP: %s" % CP.steerKpBP
+        print "CP.steerRatio: %s" % CP.steerRatio
         print "CP.steerActuatorDelay: %s" % CP.steerActuatorDelay
 
         VM.update_rt_params(CP)


### PR DESCRIPTION
Looks like you forgot to add this print statement earlier, when you added steerRatio to the tuned parameters.